### PR TITLE
Upper bound to ocaml version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@
  (synopsis "An experimental, interactive theorem prover")
  (description "Matita (that means pencil in italian) is an experimental, interactive theorem prover under development at the Computer Science Department of the University of Bologna.")
  (depends
-   (ocaml (>= "4.14.1" & < "5.0.0"))
+   (ocaml (and (>= "4.14.1") (< "5.0.0")))
    (ulex-camlp5 (>= 1.3))
    (ocaml-expat (>= 1.1.0))
    (pcre (>= 7.5.0))

--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@
  (synopsis "An experimental, interactive theorem prover")
  (description "Matita (that means pencil in italian) is an experimental, interactive theorem prover under development at the Computer Science Department of the University of Bologna.")
  (depends
-   (ocaml (>= "4.14.1"))
+   (ocaml (>= "4.14.1" & < "5.0.0"))
    (ulex-camlp5 (>= 1.3))
    (ocaml-expat (>= 1.1.0))
    (pcre (>= 7.5.0))

--- a/matita.opam
+++ b/matita.opam
@@ -15,7 +15,7 @@ doc: "http://matita.cs.unibo.it"
 bug-reports: "mailto:claudio.sacerdoticoen@unibo.it"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.14.1"}
+  "ocaml" {>= "4.14.1" & < "5.0.0"}
   "ulex-camlp5" {>= "1.3"}
   "ocaml-expat" {>= "1.1.0"}
   "pcre" {>= "7.5.0"}


### PR DESCRIPTION
When compiled using OCaml 5.0.0, Matita appears to be extremely instable as for now. As long as these issues are not dealt with, perhaps an upper bound to OCaml's version is necessary.