### PR TITLE
minor change for camlp5 8.03.00 compat

### DIFF
--- a/components/content_pres/cicNotationLexer.ml
+++ b/components/content_pres/cicNotationLexer.ml
@@ -201,6 +201,7 @@ let mk_lexer token =
     Token.tok_match = Token.default_match;
     Token.tok_text = Token.lexer_text;
     Token.tok_comm = None;
+    Token.kwds = Hashtbl.create 23;
   }
 
 let expand_macro lexbuf =


### PR DESCRIPTION
Hello, here is a tiny patch that seems to work.  I don't know much about matita, so this could be incorrect.  I'll be releasing a new version of Camlp5,  marking it incompatible with matita <= 0.99.5 (b/c build fails).  I'd be happy to help you figure out what a better fix is, if this one isn't suitable.

===================
This breaks compat with previous versions of Camlp5

OCaml 5.2.0 supports raw identifiers, e.g. "\begin".  The Camlp5 pretty-printer needs to know which "identifier-like" strings are keywords, so it can escape them as raw identifiers when pretty-printing.  Since Camlp5 supports more than one syntax, that means different syntaxes can have different sets of identifiers. Hence, the lexer has to support exposing the set of keywords, and the pretty-printer has to support being parameterized by the keywords.

matita creates a Camlp5 lexer, so it needs to be changed to have that keyword-table slot (even though it seems it doesn't use it).